### PR TITLE
Support for presets and configuring scale

### DIFF
--- a/ldraw_import.py
+++ b/ldraw_import.py
@@ -339,7 +339,7 @@ class IMPORT_OT_ldraw(bpy.types.Operator, ImportHelper):
     bl_label = "Import LDraw Model"
     bl_space_type = "PROPERTIES"
     bl_region_type = "WINDOW"
-    bl_options = {'UNDO'}
+    bl_options = {'UNDO', 'PRESET'}
     
     ## Script Options ##
     


### PR DESCRIPTION
A final pull request from this fork, because I had the changes already done, before you offered to add me to your repo.

The simplest way to add saving of properties is enabling presets. And that's what I have done here. And I threw in a scale property for good measure.

I have to admit, that I'm somewhat out of ideas what to do next. I had a look at your exporter. And while I find the idea interesting, I came to the conclusion, that it's not all that practical. LDraw is all about combining bricks out of sub-parts and to reuse as many of them as possible. To replicate this in Blender, would be a major effort. One that I'm not all that interested in.

If you have any good ideas, that don't involve property files, let's hear them. I have a long weekend coming up :).
