### PR TITLE
Update ldraw_import.py to find the parts directories on Case-Sensitive File Systems (ie. Linux, OSX)

### DIFF
--- a/ldraw_import.py
+++ b/ldraw_import.py
@@ -585,11 +585,15 @@ def locate(pattern):
 
     #lint:disable
     # Define all possible folders in the library, including unofficial bricks
+    
+    # Standard Paths:
     ldrawPath = os.path.join(LDrawDir, fname)
     hiResPath = os.path.join(LDrawDir, "p", "48", fname)
     primitivesPath = os.path.join(LDrawDir, "p", fname)
     partsPath = os.path.join(LDrawDir, "parts", fname)
     partsSPath = os.path.join(LDrawDir, "parts", "s", fname)
+    
+    # Unoffical Paths:
     UnofficialPath = os.path.join(LDrawDir, "unofficial", fname)
     UnofficialhiResPath = os.path.join(LDrawDir, "unofficial",
                                        "p", "48", fname)
@@ -600,10 +604,7 @@ def locate(pattern):
     UnofficialPartsSPath = os.path.join(LDrawDir, "unofficial",
                                         "parts", "s", fname)
     #lint:enable
-    #TODO: Why pass if fname exists? Is that line even needed?
-    if os.path.exists(fname):
-        pass
-    elif os.path.exists(ldrawPath):
+    if os.path.exists(ldrawPath):
         fname = ldrawPath
     elif os.path.exists(hiResPath) and not HighRes:  # lint:ok
         fname = hiResPath
@@ -629,8 +630,10 @@ def locate(pattern):
             isPart = True
     else:
         print("Could not find file {0}".format(fname))
-    # Needs to return a proper file or the error handling for calls to this will try to use an uninitialized variable
-    # if the file is not found.
+
+     
+    # TODO: Currently will return the inputted path, causing any error checking to clear 
+    # until it tries to actually load parts.
     return (fname, isPart)
 
 


### PR DESCRIPTION
Patch to allow finding of the ldraw parts library on case-sensitive file systems, (hopefully) without breaking compatibility on case-insensitive file systems.

Previously, this would fail if any directories in the ldraw path had capital letters in them.  I made this patch to get ldraw_import.py to work on my computer.

Also, there is a lot of error handling that needs to be fixed, they try to use variables that do not exist yet. I'll work on that next.
