### PR TITLE
 Update ldraw_import.py, Better Error Handling (Requires 9c9e15b because I forgot to make a branch)

### DIFF
--- a/ldraw_import.py
+++ b/ldraw_import.py
@@ -1,4 +1,4 @@
-    ###### BEGIN GPL LICENSE BLOCK #####
+###### BEGIN GPL LICENSE BLOCK #####
 #
 #  This program is free software; you can redistribute it and/or
 #  modify it under the terms of the GNU General Public License
@@ -27,7 +27,7 @@ bl_info = {
     "warning": "Cycles support is incomplete",
     "wiki_url": "http://wiki.blender.org/index.php/Extensions:2.6/Py/Scripts/Import-Export/LDRAW_Importer",
     #"tracker_url": "maybe"
-                    #"soon",
+                #"soon",
     "category": "Import-Export"}
 
 import os
@@ -586,14 +586,14 @@ def locate(pattern):
 
     #lint:disable
     # Define all possible folders in the library, including unofficial bricks
-    
+
     # Standard Paths:
     ldrawPath = os.path.join(LDrawDir, fname)
     hiResPath = os.path.join(LDrawDir, "p", "48", fname)
     primitivesPath = os.path.join(LDrawDir, "p", fname)
     partsPath = os.path.join(LDrawDir, "parts", fname)
     partsSPath = os.path.join(LDrawDir, "parts", "s", fname)
-    
+
     # Unoffical Paths:
     UnofficialPath = os.path.join(LDrawDir, "unofficial", fname)
     UnofficialhiResPath = os.path.join(LDrawDir, "unofficial",
@@ -632,10 +632,8 @@ def locate(pattern):
     else:
         debugPrint("Could not find file {0}".format(fname))
 
-        
-     
-    # TODO: Currently will return the inputted path, possibly causing any error checking to clear 
-    # until it tries to actually load parts.
+    # TODO: Currently will return the inputted path, possibly causing
+    # any error checking to clearuntil it tries to actually load parts.
     return (fname, isPart)
 
 
@@ -647,27 +645,31 @@ def create_model(self, scale, context):
 
     file_name = self.filepath
     debugPrint("Attempting to import {0}".format(file_name))
+
     if file_name.endswith(".ldr") or file_name.endswith(".dat") or file_name.endswith(".mpd"):
+
         try:
-    
+
             # Set the initial transformation matrix, set the scale factor to 0.05
             # and rotate -90 degrees around the x-axis, so the object is upright.
             mat = mathutils.Matrix(
                 ((1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1))) * scale
             mat = mat * mathutils.Matrix.Rotation(math.radians(-90), 4, 'X')
-    
+
             # If LDrawDir does not exist, stop the import
             if not os.path.isdir(LDrawDir):
-                debugPrint ("ERROR: Cannot find LDraw System of Tools installation at {0}".format(LDrawDir))
-                self.report({'ERROR'}, "Cannot find LDraw System of Tools installation at {0}".format(LDrawDir))
+                debugPrint(''''ERROR: Cannot find LDraw System of Tools
+                installation at {0}'''.format(LDrawDir))
+                self.report({'ERROR'}, '''Cannot find LDraw System of
+                Tools installation at {0}'''.format(LDrawDir))
                 return {'CANCELLED'}
-    
+
             colors = {}
             mat_list = {}
-    
+
             # Get material list from LDConfig
             scanLDConfig()
-    
+
             LDrawFile(context, file_name, mat)
             """
             Remove doubles and recalculate normals in each brick.
@@ -691,25 +693,33 @@ def create_model(self, scale, context):
                                                       type='EDGE_SPLIT')
                             m.split_angle = math.pi / 4
                     cur_obj.select = False
-    
+
             context.scene.update()
             objects = []
-    
+
             # Always reset 3D cursor to <0,0,0> after import
             bpy.context.scene.cursor_location = (0.0, 0.0, 0.0)
-    
+
             # Display success message
             debugPrint("{0} successfully imported!".format(file_name))
             return {'FINISHED'}
-    
+
         except Exception as e:
-            debugPrint("ERROR: "+type(e).__name__+"\n"+traceback.format_exc()+'\n')
-            debugPrint("ERROR: File not imported. Reason: "+type(e).__name__+".")
-            self.report({'ERROR'}, "File not imported ("+type(e).__name__+"). \nCheck the console logs for more information.")
+            debugPrint("ERROR: "+type(e).__name__+"\n" +
+                       traceback.format_exc()+'\n')
+
+            debugPrint("ERROR: File not imported. Reason: " +
+                       type(e).__name__ + ".")
+
+            self.report({'ERROR'}, "File not imported (" +
+                        type(e).__name__ +
+                        "). \nCheck the console logs for more information.")
             return {'CANCELLED'}
     else:
-        debugPrint("ERROR: File not imported. Reason: Invalid File Type (Must be a .dat, .ldr, or .mpd)")
-        self.report({'ERROR'}, "File not imported. Reason: Invalid File Type (Must be a .dat, .ldr, or .mpd)")
+        debugPrint("ERROR: File not imported. Reason: Invalid File Type" +
+                   "Must be a .dat, .ldr, or .mpd)")
+        self.report({'ERROR'}, "File not imported. Reason: " +
+                    "Invalid File Type (Must be a .dat, .ldr, or .mpd)")
         return {'CANCELLED'}
 
 
@@ -775,8 +785,9 @@ def getColorValue(line, value):
 
 def get_path(self, context):
     """Displays full file path of model being imported"""
-    
-    # FIXME: Currently prints the class information of the context object, not a path
+
+    # FIXME: Currently prints the class information of the
+    # context object, not a path
     debugPrint(context)
 
 
@@ -851,8 +862,9 @@ def unregister():
     bpy.utils.unregister_module(__name__)
     bpy.types.INFO_MT_file_import.remove(menu_import)
 
+
 def debugPrint(string):
     print("[LDraw Importer] "+str(string)+" - "+strftime("%H:%M:%S"))
-    
+
 if __name__ == "__main__":
     register()


### PR DESCRIPTION
## Change 1:

All outputs to the console now use a debugPrint(STRING) function which is a wrapper for:
`print('[LDraw Importer] '+STRING+' - '+CURRENT_TIME_IN_HOURS:MINUTES:SECONDS)`

This makes it easier to determine what messages come from what addons and exactly when they happened.

**EXAMPLE 1:**

```
~$: [LDraw Importer] Attempting to import /home/USER/LDCad/plane.ldr - 11:08:46
```
## Change 2:

Major error messages now display a small popup when called, notifying the user in Blender's UI, instead of silently closing the file select screen and only outputting to the console.

**EXAMPLE 2:**
![screenshot from 2013-11-06 14 00 06](https://f.cloud.github.com/assets/5861371/1480351/eaa8d522-46a8-11e3-84bf-7984cfae51f9.png)
## Change 3:

Major Error messages now identify what type of error they were, and print the stack trace where necessary.

**EXAMPLE 3:**

```
~$:[LDraw Importer] ERROR: UnicodeDecodeError
Traceback (most recent call last):
  File "ldraw_import.py", line 671, in create_model
    LDrawFile(context, file_name, mat)
  File "ldraw_import.py", line 71, in __init__
    self.parse(filename)
  File "ldraw_import.py", line 169, in parse
    lines = f_in.readlines()
  File "Software/Blender-2.69/2.69/python/lib/python3.3/codecs.py", line 300, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x90 in position 54: invalid start byte

 - 11:01:18
[LDraw Importer] ERROR: File not imported. Reason: UnicodeDecodeError. - 11:01:18
```
## Change 4:

Importing files which do not have a .ldr, .dat, or .mpd extension is no longer allowed and will not be attempted, and will tell the user through a popup in Blender's UI.

**EXAMPLE 4:**

```
[LDraw Importer] Attempting to import /home/USER/TestZipFle.zip - 11:06:53
[LDraw Importer] ERROR: File not imported. Reason: Invalid File Type (Must be a .dat, .ldr, or .mpd) - 11:06:53
```

![screenshot from 2013-11-06 13 59 23](https://f.cloud.github.com/assets/5861371/1480353/ee7b5d46-46a8-11e3-9fcb-e92e74a93d00.png)

This commit is also PEP8 Validated, except for some lines that are too long.
http://pep8online.com/s/OEEdEU2B
