### PR TITLE
Remove Video Game Cleanup option

### DIFF
--- a/Readme.html
+++ b/Readme.html
@@ -22,7 +22,7 @@
 </head>
 
 <body>
-<a name="ToC"></a><h1 class="center">LDR Importer</h1>
+<a id="ToC"></a><h1 class="center">LDR Importer</h1>
 <table>
     <tr>
         <th><strong>Table of Contents</strong></th>
@@ -48,7 +48,7 @@
 <p class="center">This is the readme for <span class="bold">LDR Importer</span>, licensed under the
 <a href="http://www.gnu.org/licenses/gpl-2.0.html" target="_blank" >General Public License Version 2.</a>
 </p>
-<a name="WhatsNeeded"></a>
+<a id="WhatsNeeded"></a>
 <br>
 
 <h3>System Requirements</h3>
@@ -58,7 +58,7 @@
     <li><a href="http://www.ldraw.org/help/getting-started.html" target="_blank">LDraw Parts Library</a></li>
     <li><a href="http://mlcad.lm-software.com/" target="_blank">MLCad</a>, <a href="http://www.leocad.org/trac" target="_blank">
     LeoCAD</a> (both optional)</li>
-</ul><a name="Install"></a>
+</ul><a id="Install"></a>
 
 <h3>Installation</h3>
 
@@ -67,7 +67,7 @@
     <li>Open Blender, and click <span class="italic">File &gt; User Preferences &gt; Addons &gt; Install from File...</span></li>
     <li>Browse for the Zip archive you downloaded and select it.</li>
     <li>Find <span class="bold">LDR Importer</span> in the list of Addons (search for "LDR" if needed), and tick the check mark to activate it.</li>
-    <li>If you want to have the script activated at all times, click the <span class="italic">Save User Settings</span> button.<a name="LDrawPath"></a></li>
+    <li>If you want to have the script activated at all times, click the <span class="italic">Save User Settings</span> button.<a id="LDrawPath"></a></li>
 </ul>
 
 <h3>Setting the LDraw Folder Path</h3>
@@ -85,22 +85,23 @@
 </ul>
 <br>
 <p class="center">That's it! You have successfully installed <span class="bold">LDR Importer</span> and can now import your LDraw models!</p>
-<a name="Changes"></a>
+<a id="Changes"></a>
 
 <h2>Please Note</h2>
 <p>If a brick cannot be found in the parts library, the import will suddenly stop with no visible error message.
 This is planned to be fixed as soon as possible.</p>
 
 <h2>Change Log</h2>
-    
+
 <strong>1.2</strong><br>
 (Released ?? ??, 2014)<br>
 <ul>
     <li>Read <code>LDConfig.ldr</code> and <code>config.py</code> using <code>UTF-8</code> encoding</li>
     <li>Added support for reading models in <code>UCS-2BE</code> & <code>UCS-2LE</code> encoding (see <a href="https://github.com/le717/LDR-Importer/issues/37" target="_blank">Issue #37</a>)</li>
-    <li>Always save <code>config.py</code> in user's <code>AppData</code> on Windows (see <a href="https://github.com/le717/LDR-Importer/issues/38" target="_blank">Issue #38/a>)</li>
+    <li>Always save <code>config.py</code> in user's <code>AppData</code> on Windows (see <a href="https://github.com/le717/LDR-Importer/issues/38" target="_blank">Issue #38</a>)</li>
+    <li>Remove <code>GameFix</code> import option</li>
 </ul>
-    
+
 <strong>1.1</strong><br>
 <em>The Working Quartet</em><br>
 (Released December 2, 2013)<br>
@@ -310,7 +311,7 @@ This is planned to be fixed as soon as possible.</p>
 (Released February 23, 2012)<br>
 <ul>
     <li>Original version by David Pluntze</li>
-</ul><a name="Support"></a>
+</ul><a id="Support"></a>
 
 <h2>Support</h2>
 <p>To submit bug reports or get the newest, bleeding-edge script, please go to

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -814,22 +814,12 @@ Must be a .ldr or .dat''')
             Cleanup can be disabled by user if wished.
             """
 
-            # Default values for model cleanup options
-            CleanUp = False
-            GameFix = False
-
             # The CleanUp option was selected
             if CleanUpOpt == "CleanUp":  # lint:ok
                 CleanUp = True
+
+            if CleanUp:  # lint:ok
                 debugPrint("CleanUp option selected")
-
-            # The GameFix option was selected
-            elif CleanUpOpt == "GameFix":  # lint:ok
-                GameFix = True
-                debugPrint("GameFix option selected")
-
-            # Standard cleanup actions
-            if (CleanUp or GameFix):  # lint:ok
 
                 # Select all the mesh
                 for cur_obj in objects:
@@ -853,27 +843,11 @@ Must be a .ldr or .dat''')
                             # Set smooth shading
                             bpy.ops.object.shade_smooth()
 
-           # -------- Actions only for CleanUp option -------- #
-
-            if CleanUp:  # lint:ok
-                # Add 30 degree edge split modifier to all bricks
-                for cur_obj in objects:
-                    edges = cur_obj.modifiers.new(
-                        "Edge Split", type='EDGE_SPLIT')
-                    edges.split_angle = 0.523599
-
-            # -------- Actions only for GameFix option -------- #
-
-            if GameFix:  # lint:ok
-                for cur_obj in objects:
-                    # Add 0.7 ratio decimate modifier to all bricks
-                    deci = cur_obj.modifiers.new("Decimate", type='DECIMATE')
-                    deci.ratio = 0.7
-
-                    # Add 45 degree edge split modifier to all bricks
-                    edges = cur_obj.modifiers.new("Edge Split",
-                                                  type='EDGE_SPLIT')
-                    edges.split_angle = 0.802851
+                            # Add 30 degree edge split modifier to all bricks
+                            for cur_obj in objects:
+                                edges = cur_obj.modifiers.new(
+                                    "Edge Split", type='EDGE_SPLIT')
+                                edges.split_angle = 0.523599
 
             # Select all the mesh now that import is complete
             for cur_obj in objects:
@@ -1024,8 +998,6 @@ def hex_to_rgb(rgb_str):
 CLEANUP_OPTIONS = (
     ("CleanUp", "Basic Cleanup",
      "Removes double vertices, recalculate normals, add Edge Split modifier"),
-    ("GameFix", "Video Game Optimization",
-     "Optimize model for video game usage (Decimate Modifier)"),
     ("DoNothing", "Original LDraw Mesh", "Import LDraw Mesh as Original"),
 )
 


### PR DESCRIPTION
@rioforce told me it is not really needed at all, and I have witnessed mesh breakage with it, most notably when the [initial patch](https://github.com/le717/LDR-Importer/issues/40#issuecomment-31279788) for #40 is applied.
