### PR TITLE
Rework part encoding and reading

### DIFF
--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -95,16 +95,6 @@ config_filename = os.path.abspath(os.path.join(config_path, "config.py"))
 #FIXME: v1.2 rewrite - Placeholder until rewrite.
 file_directory = ""
 
-
-def debugPrint(*myInput):
-    """Debug print with identification timestamp"""
-    # Format the output like print() does
-    myOutput = [str(say) for say in myInput]
-
-    # `strftime("%H:%M:%S.%f")[:-4]` trims milliseconds down to two places
-    print("\n[LDR Importer] {0} - {1}\n".format(
-        " ".join(myOutput), datetime.now().strftime("%H:%M:%S.%f")[:-4]))
-
 # Attempt to read and use the path in the config
 try:
     # A hacky trick that basically is: from config import *
@@ -130,6 +120,17 @@ except Exception as e:
                type(e).__name__))
 
 
+def debugPrint(*myInput):
+    """Debug print with identification timestamp"""
+
+    # Format the output like print() does
+    myOutput = [str(say) for say in myInput]
+
+    # `strftime("%H:%M:%S.%f")[:-4]` trims milliseconds down to two places
+    print("\n[LDR Importer] {0} - {1}\n".format(
+        " ".join(myOutput), datetime.now().strftime("%H:%M:%S.%f")[:-4]))
+
+
 def checkEncoding(encoding):
     """Check the encoding of a part"""
 
@@ -142,29 +143,38 @@ def checkEncoding(encoding):
     elif encoding in (b"\xff\xfe0", b"\xff\xfe/"):
         return "utf_16_le"
 
-    # Use LDraw model stantard UTF-8
+    # Use LDraw part standard UTF-8
     else:
         return "utf_8"
 
 
-def readPart(filePath):
+def readPart(partPath):
     """Read parts using their proper encoding"""
 
-    # First, read the part as bytes
-    with open(filePath, "rb") as f:
+    debugPrint("Part being read: ", partPath)
+    # First, read the part content as bytes
+    with open(partPath, "rb") as f:
         partContent = f.read()
 
-    # Then get the part encoding
+    # Then, get the part encoding
     partEncoding = checkEncoding(partContent[:3])
+    debugPrint("Part encoding, Encoding header: ",
+               partEncoding, partContent[:3])
 
-    # Now convert the bytes to the proper string encoding
+    # Now decode the bytes to the proper string encoding
     partContent = partContent.decode(partEncoding).encode("utf-8")
 
-    # Use proper new line characters depending on file encoding
+    # Split into an array using appropriate new line characters
+    # depending on the file encoding
     if partEncoding == "utf_16_le":
+        debugPrint("UTF-16LE encoding detected, use \\n new lines")
         partContent = str(partContent, partEncoding).split("\n")
     else:
+        debugPrint("UTF-8 or UTF-16BE encoding detected, use \\r\\n new lines")
         partContent = str(partContent, partEncoding).split("\r\n")
+
+    debugPrint("The part content type is an: ", type(partContent))
+    debugPrint("(Should be <class 'list'>)")
 
     return partContent
 

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -66,7 +66,7 @@ Index 3: User defined, raw string
 Storing the paths in a list prevents the creation of global variables
 if they are changed. Instead, simply update the proper index.
 """
-LDrawDirs = ["C:\\LDraw", "/Applications/ldraw/", "~/ldraw/", r""]
+LDrawDirs = [r"C:\LDraw", "/Applications/ldraw/", "~/ldraw/", r""]
 
 
 def debugPrint(*myInput):
@@ -155,45 +155,28 @@ def getNewLineChar(partPath):
     regex = re.compile(b"(\r\n)$|\r$|\n$")
     match = regex.search(line)
     if match:
-        return str(match.group(0))
-    return "\n"
+        return match.group(0)
+    return b"\n"
 
 
 def readPart(partPath):
     """Read parts using their proper encoding."""
-    debugPrint("Part being read: ", partPath)
-    # First, read the part content as bytes
+    debugPrint("Part being read:\n{0}".format(partPath))
+    # Read the part content as bytes
     with open(partPath, "rb") as f:
         partContent = f.read()
 
-    # Then, get the part encoding
+    # Get the part encoding
     partEncoding = checkEncoding(partContent[:3])
-    debugPrint("Part encoding, Encoding header: ",
-               partEncoding, partContent[:3])
 
-    # Now decode the bytes to the proper string encoding
+    # Convert the bytes to UTF-8 encoding (as they should be)
+    # TODO Remove the BOM
     partContent = partContent.decode(partEncoding).encode("utf-8")
-    newLineChar = getNewLineChar(partPath)
-    
-    print("newlineChar", [newLineChar])
+    newLineChar = b"\r\n"
 
-    # Split into an array using appropriate new line characters
-    # depending on the file encoding
-#    if partEncoding == "utf_16_le":
-#    if partEncoding == "utf_16_be":
-#        newLineChar = r"\r\n"
-#        debugPrint("UTF-16LE encoding detected, use \\n new lines")
-#        partContent = str(partContent, partEncoding).split("\n")
-#    else:
-#        debugPrint("UTF-8 or UTF-16BE encoding detected, use \\r\\n new lines")
-#        partContent = str(partContent, partEncoding).split("\r\n")
-#    partContent = str(partContent, partEncoding).split(newLineChar)
-    partContent = str(partContent, partEncoding).split(newLineChar)
-
-#    debugPrint("The part content type is an: ", type(partContent))
-#    debugPrint("(Should be <class 'list'>)")
-
-    debugPrint(partContent)
+    # Break it into an array, convert to a string
+    partContent = partContent.split(newLineChar)
+    partContent = [str(line, "utf-8") for line in partContent]
     return partContent
 
 

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -148,23 +148,25 @@ def checkEncoding(encoding):
 
 
 def readPart(filePath):
-    """Read parts using their proper encoding (#37)"""
+    """Read parts using their proper encoding"""
 
     # First, read the part as bytes
     with open(filePath, "rb") as f:
-        partContent= f.readlines()
+        partContent = f.read()
 
     # Then get the part encoding
-    partEncoding = checkEncoding(partContent[0][:3])
+    partEncoding = checkEncoding(partContent[:3])
 
-    #if partEncoding == "utf_16_le":
-    #    debugPrint("UTF-16-LE detected")
+    # Now convert the bytes to the proper string encoding
+    partContent = partContent.decode(partEncoding).encode("utf-8")
 
-    # Now convert the bytes to the proper encoding, replacing misunderstood characters
-    # with understood ones
-    # (replacing would only occur in part header, per LDraw file format)
-#    return [strLine.decode(partEncoding, "ignore") for strLine in partContent]
-    return [strLine.decode(partEncoding, "replace") for strLine in partContent]
+    # Use proper new line characters depending on file encoding
+    if partEncoding == "utf_16_le":
+        partContent = str(partContent, partEncoding).split("\n")
+    else:
+        partContent = str(partContent, partEncoding).split("\r\n")
+
+    return partContent
 
 
 class LDrawFile(object):

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -134,7 +134,7 @@ except Exception as e:
 def checkEncoding(byteOrderMark):
     """Check the encoding of a part."""
     # The file uses UCS-2 (UTF-16) Big Endian encoding
-    if byteOrderMark == b"\xfe\xff\x00":
+    if b"\xfe\xff\x00" in byteOrderMark:
         return ("utf_16_be", byteOrderMark)
 
     # The file uses UCS-2 (UTF-16) Little Endian
@@ -152,7 +152,7 @@ def getNewLineChar(partPath):
     with open(partPath, "rb") as f:
         line = f.readline()
 
-    regex = re.compile(b"(\r\n)$|\r$|\n$")
+    regex = re.compile(b"(\r\n)$|\r$")
     match = regex.search(line)
     if match:
         return match.group(0)
@@ -171,10 +171,10 @@ def readPart(partPath):
 
     # Convert the bytes to UTF-8 encoding (as they should be)
     partContent = partContent.decode(partEncoding).encode("utf-8")
-    newLineChar = b"\r\n"
+    newLineChar = getNewLineChar(partPath)
 
     # Remove the BOM
-    if (byteOrderMark is not None):
+    if byteOrderMark is not None:
         partContent.replace(byteOrderMark, b"")
 
     # Break it into an array, convert to a string

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -148,6 +148,12 @@ def checkEncoding(encoding):
         return "utf_8"
 
 
+def getNewLineChar(partPath):
+    """Detect a part's new line character"""
+    with open(partPath, "rb") as f:
+        line = f.readline()
+
+
 def readPart(partPath):
     """Read parts using their proper encoding"""
 


### PR DESCRIPTION
Because the original script relies on a bit of the part header to work, preventing it from being stripped (#76), this is a different method to solving the `UnicodeDecodeError` in #75.

This method reads the file as bytes, checks the part encoding, then decodes the data into the proper string encoding. If any characters cannot be decoded, the character is replaced with a suitable substitute. 

This also backports the fixed encoding check from Next Gen (e7fe547b0d42873e47116fed179f983b3b75eadf).
 
**Todo**
- [x] UCS-2 (UTF-16) Little Endian are not working. Import completely stops.
- [ ] Make it work on Mac OSX and Linux