### PR TITLE
New Cycles materials

### DIFF
--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -415,7 +415,7 @@ def getCyclesMaterial(colour):
                 mat = getCyclesMilkyWhite("Mat_{0}_".format(colour),
                                           col["color"])
 
-            elif (col["material"] == "BASIC" and col["luminance"]) == 0:
+            elif col["material"] == "BASIC" and col["luminance"] == 0:
                 mat = getCyclesBase("Mat_{0}_".format(colour),
                                     col["color"], col["alpha"])
 

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -482,11 +482,7 @@ def getCyclesBase(name, diffColor, alpha):
 
     # Transparent bricks
     else:
-        """
-        The alpha transparency used by LDraw is too simplistic for Cycles,
-        so I'm not using the value here. Other transparent colors
-        like 'Milky White' will need special materials.
-        """
+        # TODO Figure out a good way to make use of the alpha value
         node = nodes.new('ShaderNodeBsdfGlass')
         node.location = -242, 154
         node.inputs['Color'].default_value = diffColor + (1.0,)


### PR DESCRIPTION
This completes part of #9.

Implement some of @rioforce's [LEGO Cycles materials](https://rioforce.wordpress.com/2013/10/10/lego-materials-in-blender-cycles/), specifically new materials for Chrome, Pearlescent, and Rubber colors. The Chrome and trans-rubber materials do not match what is documented in the post, as they are newly defined (read: right before the code for them was implemented).

Also fixes a bug spotted by rioforce and @BertVanRaemdonck (Bert also identified the fix) that blocked most of the materials from being used.