### PR TITLE
Add support for direct colors

### DIFF
--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -417,6 +417,20 @@ def getMaterial(colour):
             mat_list[colour] = mat
 
         return mat_list[colour]
+    else:
+        # Check for a possible direct color
+        directColor = convertDirectColor(colour)
+
+        # We have a direct color on our hands
+        if directColor[0]:
+            debugPrint("Direct color {0} found".format(colour))
+            mat = bpy.data.materials.new("Mat_{0}_".format(colour))
+            mat.diffuse_color = directColor[1]
+
+            # Add it to the material lists to avoid duplicate processing
+            colors[colour] = mat
+            mat_list[colour] = mat
+            return mat_list[colour]
 
     return None
 

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -348,6 +348,7 @@ class LDrawFile(object):
             else:
                 break
 
+
 def convertDirectColor(color):
     """Convert direct colors to usable RGB values.
 
@@ -359,7 +360,7 @@ def convertDirectColor(color):
                                      converted into a three-index
                                      RGB color tuple.
     """
-    if re.fullmatch(r"^0x2(?:[\A-F0-9]{2}){3}$", color) is None:
+    if re.fullmatch(r"^0x2(?:[A-F0-9]{2}){3}$", color) is None:
         return (False,)
     return (True, hex_to_rgb(color.lstrip("0x2")))
 
@@ -484,18 +485,12 @@ def getCyclesMaterial(colour):
         if directColor[0]:
             debugPrint("Direct color {0} found".format(colour))
             mat = getCyclesBase("Mat_{0}_".format(colour),
-                                             directColor[1], 1.0)
+                                directColor[1], 1.0)
 
-        # Some other color format, keep it Blender default gray
-        else:
-            debugPrint("Unknown color format {0} found".format(colour))
-            mat = getCyclesBase("Mat_{0}_".format(colour),
-                                             (0.8, 0.8, 0.8), 1.0)
-
-        # Add it to the material lists to avoid duplicate processing
-        colors[colour] = mat
-        mat_list[colour] = mat
-        return mat_list[colour]
+            # Add it to the material lists to avoid duplicate processing
+            colors[colour] = mat
+            mat_list[colour] = mat
+            return mat_list[colour]
 
     return None
 


### PR DESCRIPTION
This fixes #63 by adding support for [direct colors](http://www.ldraw.org/article/218.html#colours). It also fixes #92 and an unreported bug in Cycles where parts that could not be assigned a material were colored yellow.