### PR TITLE
Restore debugPrint() for patch compatibility

### DIFF
--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -42,6 +42,21 @@ paths = []
 mat_list = {}
 
 
+def debugPrint(msg):
+    """Compatibility function for easier debugging of older patches.
+
+    Do not use this function in new code! Always use the appropriate
+    static method in the Console class when displaying information
+    in the Blender console. This function may be removed by
+    the developers at any time and will not be permanent.
+
+    @param {String} msg The message to be displayed.
+    """
+    Console.warn("""debugPrint() is deprecated!
+Use the appropriate Console method instead.""")
+    Console.log(msg)
+
+
 class LDrawFile(object):
 
     """Scans LDraw files."""

--- a/src/ldutils.py
+++ b/src/ldutils.py
@@ -27,15 +27,40 @@ from datetime import datetime
 class Console:
 
     @staticmethod
-    def log(*msg):
-        """Log debug messages to the console.
+    def __makeMessage(msg, prefix=None):
+        """Construct the message for displaying in the console.
 
-        @param {Tuple} msg The messages to be displayed.
+        Formats, timestamps, and identifies the message
+        as coming from this script.
+
+        @param {Tuple} msg The message to be displayed.
+        @param {String} prefix Any text to prefix to the message.
+        @return {String} The constucted message.
         """
         msg = [str(text) for text in msg]
-        print("[LDR Importer] {0} - {1}\n".format(
-              " ".join(msg),
-              datetime.now().strftime("%H:%M:%S.%f")[:-4]))
+
+        # Prefix text if needed
+        if prefix:
+            msg.insert(0, str(prefix))
+
+        return "[LDR Importer] ({0})\n{1}".format(
+            datetime.now().strftime("%H:%M:%S.%f")[:-4], " ".join(msg))
+
+    @staticmethod
+    def log(*msg):
+        """Print logging messages to the console.
+
+        @param {Tuple} msg The message to be displayed.
+        """
+        print(Console.__makeMessage(msg))
+
+    @staticmethod
+    def warn(*msg):
+        """Print warning messages to the console.
+
+        @param {Tuple} msg The message to be displayed.
+        """
+        print(Console.__makeMessage(msg, "Warning!"))
 
 
 class Preferences:


### PR DESCRIPTION
This lead to multiple changes to the Console class:
+ Add new private `__makeMessage()` method to construct the message
+ Add new `warn()` static method
+ Update `log()` method to use `__makeMessage()`
+ Better message formatting
+ `debugPrint()` displays a deprecation message when called

The behavior of debugPrint has been altered slightly, though it was
never fully documented to begin with. Originally it worked in the same
manner as `print()`, accepting multiple unnamed parameters and
constructing one message. Now, it only accepts a single string (as
it was always used) and the Console methods accept the old behavior.