### PR TITLE
Persist import options between Blender launches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ python:
 
 install: pip install -r requirements.txt
 script:
-  - flake8 --max-complexity 10 .
+  - flake8 .
   - pep257 . --explain

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1052,7 +1052,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
 
     # Import options
 
-    scale = FloatProperty(
+    importScale = FloatProperty(
         name="Scale",
         description="Use a specific scale for each part",
         default=prefs.get("importScale", 1.00)
@@ -1097,7 +1097,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         default=prefs.get("lsynthParts", False)
     )
 
-    links = BoolProperty(
+    linkParts = BoolProperty(
         name="Link Identical Parts",
         description="Link identical parts by type and color",
         default=prefs.get("linkParts", True)
@@ -1110,7 +1110,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         box.label("Import Options", icon='SCRIPTWIN')
         box.label("LDraw Path", icon='FILESEL')
         box.prop(self, "ldrawPath")
-        box.prop(self, "scale")
+        box.prop(self, "importScale")
         box.label("Primitives", icon='MOD_BUILD')
         box.prop(self, "resPrims", expand=True)
         box.label("Model Cleanup", icon='EDIT')
@@ -1118,7 +1118,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         box.label("Additional Options", icon='PREFERENCES')
         box.prop(self, "addGaps")
         box.prop(self, "lsynthParts")
-        box.prop(self, "links")
+        box.prop(self, "linkParts")
 
     def execute(self, context):
         """Set import options and run the script."""
@@ -1128,7 +1128,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         CleanUpOpt = str(self.cleanUpModel)
         GapsOpt = bool(self.addGaps)
         LSynth = bool(self.lsynthParts)
-        LinkParts = bool(self.links)
+        LinkParts = bool(self.linkParts)
 
         # Clear array before adding data if it contains data already
         # Not doing so duplicates the indexes
@@ -1187,13 +1187,13 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         # Create the preferences dictionary
         importOpts = {
             "addGaps": self.addGaps,
-            "importScale": self.scale,
-            "linkParts": self.links,
+            "importScale": self.importScale,
+            "linkParts": self.linkParts,
             "lsynthParts": self.lsynthParts
         }
 
         # Save the preferences and import the model
         self.prefs.setLDraw(self.ldrawPath)
         self.prefs.save(importOpts)
-        create_model(self, context, self.scale)
+        create_model(self, context, self.importScale)
         return {'FINISHED'}

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -34,7 +34,8 @@ from bpy.props import (StringProperty,
 
 from bpy_extras.io_utils import ImportHelper
 
-from .src.ldutils import (Console, Preferences)
+from .src.ldconsole import Console
+from .src.ldprefs import Preferences
 
 # Global variables
 objects = []

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1054,8 +1054,8 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
 
     scale = FloatProperty(
         name="Scale",
-        description="Use a specific scale for each brick",
-        default=1.00
+        description="Use a specific scale for each part",
+        default=prefs.get("importScale", 1.00)
     )
 
     resPrims = EnumProperty(
@@ -1184,7 +1184,15 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         # Finally, search in the `p` folder
         paths.append(os.path.join(LDrawDir, "p"))
 
-        # Save any preferences and import the model
+        # Create the preferences dictionary
+        importOpts = {
+            "addGaps": self.addGaps,
+            "importScale": self.scale,
+            "linkParts": self.links,
+            "lsynthParts": self.lsynthParts
+        }
+
+        # Save the preferences and import the model
         self.prefs.setLDraw(self.ldrawPath)
         self.prefs.save()
         create_model(self, context, self.scale)

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1188,6 +1188,6 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
 
         # Save any preferences and import the model
         self.prefs.setLDraw(self.ldrawPath)
-        self.prefs.savePrefs()
+        self.prefs.save()
         create_model(self, context, self.scale)
         return {'FINISHED'}

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1061,6 +1061,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
     resPrims = EnumProperty(
         name="Resolution of part primitives",
         description="Resolution of part primitives",
+        default=prefs.get("resPrims", "StandardRes"),
         items=(
             ("StandardRes", "Standard Primitives",
              "Import using standard resolution primitives"),
@@ -1073,9 +1074,10 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         )
     )
 
-    cleanUpModel = EnumProperty(
+    cleanUpParts = EnumProperty(
         name="Model Cleanup Options",
         description="Model Cleanup Options",
+        default=prefs.get("cleanUpParts", "CleanUp"),
         items=(
             ("CleanUp", "Basic Cleanup",
              "Remove double vertices, recalculate normals, "
@@ -1114,7 +1116,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         box.label("Primitives", icon='MOD_BUILD')
         box.prop(self, "resPrims", expand=True)
         box.label("Model Cleanup", icon='EDIT')
-        box.prop(self, "cleanUpModel", expand=True)
+        box.prop(self, "cleanUpParts", expand=True)
         box.label("Additional Options", icon='PREFERENCES')
         box.prop(self, "addGaps")
         box.prop(self, "lsynthParts")
@@ -1124,10 +1126,8 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         """Set import options and run the script."""
         global LDrawDir, CleanUpOpt, GapsOpt, LinkParts
         LDrawDir = str(self.ldrawPath)
-        WhatRes = str(self.resPrims)
-        CleanUpOpt = str(self.cleanUpModel)
+        CleanUpOpt = str(self.cleanUpParts)
         GapsOpt = bool(self.addGaps)
-        LSynth = bool(self.lsynthParts)
         LinkParts = bool(self.linkParts)
 
         # Clear array before adding data if it contains data already
@@ -1147,17 +1147,17 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
             paths.append(os.path.join(LDrawDir, "unofficial", "parts"))
 
             # The user wants to use high-res unofficial primitives
-            if WhatRes == "HighRes":
+            if self.resPrims == "HighRes":
                 paths.append(os.path.join(LDrawDir, "unofficial", "p", "48"))
             # The user wants to use low-res unofficial primitives
-            elif WhatRes == "LowRes":
+            elif self.resPrims == "LowRes":
                 paths.append(os.path.join(LDrawDir, "unofficial", "p", "8"))
 
             # Search in the `unofficial/p` folder
             paths.append(os.path.join(LDrawDir, "unofficial", "p"))
 
             # The user wants to use LSynth parts
-            if LSynth:
+            if self.lsynthParts:
                 if os.path.exists(os.path.join(LDrawDir, "unofficial",
                                                "lsynth")):
                     paths.append(os.path.join(LDrawDir, "unofficial",
@@ -1168,12 +1168,12 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         paths.append(os.path.join(LDrawDir, "parts"))
 
         # The user wants to use high-res primitives
-        if WhatRes == "HighRes":
+        if self.resPrims == "HighRes":
             paths.append(os.path.join(LDrawDir, "p", "48"))
             Console.log("High-res primitives substitution selected")
 
         # The user wants to use low-res primitives
-        elif WhatRes == "LowRes":
+        elif self.resPrims == "LowRes":
             paths.append(os.path.join(LDrawDir, "p", "8"))
             Console.log("Low-res primitives substitution selected")
 
@@ -1187,9 +1187,11 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         # Create the preferences dictionary
         importOpts = {
             "addGaps": self.addGaps,
+            "cleanUpParts": self.cleanUpParts,
             "importScale": self.importScale,
             "linkParts": self.linkParts,
-            "lsynthParts": self.lsynthParts
+            "lsynthParts": self.lsynthParts,
+            "resPrims": self.resPrims
         }
 
         # Save the preferences and import the model

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1086,21 +1086,21 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
     )
 
     addGaps = BoolProperty(
-        name="Spaces Between Bricks",
-        description="Add small spaces between each brick",
-        default=False
+        name="Spaces Between Parts",
+        description="Add small spaces between each part",
+        default=prefs.get("addGaps", False)
     )
 
     lsynthParts = BoolProperty(
         name="Use LSynth Parts",
         description="Use LSynth parts during import",
-        default=False
+        default=prefs.get("lsynthParts", False)
     )
 
     links = BoolProperty(
-        name="Link Identical Bricks",
+        name="Link Identical Parts",
         description="Link identical parts by type and color",
-        default=True
+        default=prefs.get("linkParts", True)
     )
 
     def draw(self, context):
@@ -1132,11 +1132,8 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
 
         # Clear array before adding data if it contains data already
         # Not doing so duplicates the indexes
-        try:
-            if paths[0]:
-                del paths[:]
-        except IndexError:
-            pass
+        if paths:
+            del paths[:]
 
         # Create placeholder for index 0.
         # It will be filled with the location of the model later.

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1194,6 +1194,6 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
 
         # Save the preferences and import the model
         self.prefs.setLDraw(self.ldrawPath)
-        self.prefs.save()
+        self.prefs.save(importOpts)
         create_model(self, context, self.scale)
         return {'FINISHED'}

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1025,7 +1025,7 @@ def hexToRgb(color):
 
 class LDRImporterOps(bpy.types.Operator, ImportHelper):
 
-    """LDR Importer Operator."""
+    """LDR Importer Import Operator."""
 
     bl_idname = "import_scene.ldraw"
     bl_description = "Import an LDraw model (.ldr/.dat)"

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -1047,7 +1047,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
     ldrawPath = StringProperty(
         name="",
         description="Path to the LDraw Parts Library",
-        default=prefs.findLDraw()
+        default=prefs.getLDraw()
     )
 
     # Import options
@@ -1193,7 +1193,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         }
 
         # Save the preferences and import the model
-        self.prefs.setLDraw(self.ldrawPath)
+        self.prefs.saveLDraw(self.ldrawPath)
         self.prefs.save(importOpts)
         create_model(self, context, self.importScale)
         return {'FINISHED'}

--- a/src/ldconsole.py
+++ b/src/ldconsole.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""LDR Importer GPLv2 license.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""
+
+
+from datetime import datetime
+
+
+class Console:
+
+    @staticmethod
+    def __makeMessage(msg, prefix=None):
+        """Construct the message for displaying in the console.
+
+        Formats, timestamps, and identifies the message
+        as coming from this script.
+
+        @param {Tuple} msg The message to be displayed.
+        @param {String} prefix Any text to prefix to the message.
+        @return {String} The constucted message.
+        """
+        msg = [str(text) for text in msg]
+
+        # Prefix text if needed
+        if prefix:
+            msg.insert(0, str(prefix))
+
+        return "[LDR Importer] ({0})\n{1}".format(
+            datetime.now().strftime("%H:%M:%S.%f")[:-4], " ".join(msg))
+
+    @staticmethod
+    def log(*msg):
+        """Print logging messages to the console.
+
+        @param {Tuple} msg The message to be displayed.
+        """
+        print(Console.__makeMessage(msg))
+
+    @staticmethod
+    def warn(*msg):
+        """Print warning messages to the console.
+
+        @param {Tuple} msg The message to be displayed.
+        """
+        print(Console.__makeMessage(msg, "Warning!"))

--- a/src/ldconsole.py
+++ b/src/ldconsole.py
@@ -40,7 +40,7 @@ class Console:
         if prefix:
             msg.insert(0, str(prefix))
 
-        return "[LDR Importer] ({0})\n{1}".format(
+        return "\n[LDR Importer] ({0}) {1}".format(
             datetime.now().strftime("%H:%M:%S.%f")[:-4], " ".join(msg))
 
     @staticmethod

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -86,7 +86,7 @@ class Preferences:
         """
         return os.path.isfile(os.path.join(ldPath, "LDConfig.ldr"))
 
-    def findLDraw(self):
+    def __findLDraw(self):
         """Try to find an LDraw installation.
 
         @return {String} The found LDraw installation
@@ -120,7 +120,7 @@ class Preferences:
         Console.log("Search {0}-specific paths for the LDraw path".format(
                     self.__curPlatform))
         for path in self.__paths[self.__curPlatform]:
-            if self.setLDraw(path):
+            if self.saveLDraw(path):
                 return path
 
         # We came up dry, default to Windows default
@@ -129,7 +129,7 @@ class Preferences:
                     self.__ldPath))
         return self.__ldPath
 
-    def setLDraw(self, ldPath):
+    def saveLDraw(self, ldPath):
         """Set the LDraw installation.
 
         @param {String} ldPath The LDraw installation
@@ -158,6 +158,13 @@ class Preferences:
             return options[opt]
         return default
 
+    def getLDraw(self):
+        """Retrieve the LDraw installation.
+
+        @return {String} The LDraw installation."""
+        return (self.__ldPath if self.__ldPath is not None
+                else self.__findLDraw())
+
     def save(self, importOpts):
         """Write the JSON preferences.
 
@@ -169,6 +176,9 @@ class Preferences:
         for k, v in importOpts.items():
             if type(v) == float:
                 importOpts[k] = round(v, 2)
+
+        # Update the in-memory preferences
+        self.__prefsData["importOpts"] = importOpts
 
         prefs = {
             "importOpts": importOpts,

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -21,46 +21,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 import os
 import json
 import platform
-from datetime import datetime
 
-
-class Console:
-
-    @staticmethod
-    def __makeMessage(msg, prefix=None):
-        """Construct the message for displaying in the console.
-
-        Formats, timestamps, and identifies the message
-        as coming from this script.
-
-        @param {Tuple} msg The message to be displayed.
-        @param {String} prefix Any text to prefix to the message.
-        @return {String} The constucted message.
-        """
-        msg = [str(text) for text in msg]
-
-        # Prefix text if needed
-        if prefix:
-            msg.insert(0, str(prefix))
-
-        return "[LDR Importer] ({0})\n{1}".format(
-            datetime.now().strftime("%H:%M:%S.%f")[:-4], " ".join(msg))
-
-    @staticmethod
-    def log(*msg):
-        """Print logging messages to the console.
-
-        @param {Tuple} msg The message to be displayed.
-        """
-        print(Console.__makeMessage(msg))
-
-    @staticmethod
-    def warn(*msg):
-        """Print warning messages to the console.
-
-        @param {Tuple} msg The message to be displayed.
-        """
-        print(Console.__makeMessage(msg, "Warning!"))
+from .ldconsole import Console
 
 
 class Preferences:

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -129,24 +129,13 @@ class Preferences:
                     self.__ldPath))
         return self.__ldPath
 
-    def saveLDraw(self, ldPath):
-        """Set the LDraw installation.
-
-        @param {String} ldPath The LDraw installation
-        @return {Boolean} True if the installation was set, False otherwise.
-        """
-        if self.__confirmLDraw(ldPath):
-            Console.log("Found LDraw installation at {0}".format(ldPath))
-            self.__ldPath = ldPath.replace("\\", "/")
-            return True
-        return False
-
     def get(self, opt, default):
         """Retrieve the desired import option from the preferences.
 
         @param {String} opt The key for the import option desired.
-        @param {TODO} default TODO.
-        @return {TODO} TODO.
+        @param {Boolean|Number|String} default Default value if a value cannot
+                                               be retrieved from the prefs.
+        @return {Boolean|Number|String} The import option to use.
         """
         # Make sure we have preferences to use
         if self.__prefsData is None or not self.__prefsData["importOpts"]:
@@ -161,14 +150,15 @@ class Preferences:
     def getLDraw(self):
         """Retrieve the LDraw installation.
 
-        @return {String} The LDraw installation."""
+        @return {String} The LDraw installation.
+        """
         return (self.__ldPath if self.__ldPath is not None
                 else self.__findLDraw())
 
     def save(self, importOpts):
         """Write the JSON preferences.
 
-        @param {Dictionary} importOpts TODO.
+        @param {Dictionary} importOpts The import options to save.
         @return {Boolean} True if the preferences were written,
                           False otherwise.
         """
@@ -178,7 +168,8 @@ class Preferences:
                 importOpts[k] = round(v, 2)
 
         # Update the in-memory preferences
-        self.__prefsData["importOpts"] = importOpts
+        if self.__prefsData is not None:
+            self.__prefsData["importOpts"] = importOpts
 
         prefs = {
             "importOpts": importOpts,
@@ -192,12 +183,22 @@ class Preferences:
 
         try:
             with open(self.__prefsFile, "wt", encoding="utf_8") as f:
-                # TODO Consder removing the indent parameter
-                # once work on the system is completed.
-                f.write(json.dumps(prefs, indent=4, sort_keys=True))
-            Console.log("Preferences saved to {0}".format(self.__prefsFile))
+                f.write(json.dumps(prefs, sort_keys=True))
+            Console.log("Preferences saved to\n{0}".format(self.__prefsFile))
             return True
 
         # Silently fail
         except PermissionError:
             return False
+
+    def saveLDraw(self, ldPath):
+        """Set the LDraw installation.
+
+        @param {String} ldPath The LDraw installation
+        @return {Boolean} True if the installation was set, False otherwise.
+        """
+        if self.__confirmLDraw(ldPath):
+            Console.log("Found LDraw installation at {0}".format(ldPath))
+            self.__ldPath = ldPath.replace("\\", "/")
+            return True
+        return False

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -142,6 +142,17 @@ class Preferences:
             return True
         return False
 
+    def get(self, opt, default):
+        # Make sure we have preferences to use
+        if self.__prefsData is None or not self.__prefsData["importOpts"]:
+            return default
+
+        # Retrieve the desired import option
+        options = self.__prefsData["importOpts"]
+        if opt in options.keys():
+            return options[opt]
+        return default
+
     def save(self):
         """Write the JSON-based preferences file.
 
@@ -149,9 +160,9 @@ class Preferences:
                            False otherwise.
         """
         prefs = {
-            "platform": self.__curPlatform,
+            "importOpts": {},
             "ldPath": self.__ldPath,
-            "importOpts": {}
+            "platform": self.__curPlatform
         }
 
         # Create the preferences folder if it does not exist

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -56,7 +56,7 @@ class Preferences:
     def __getPrefsDir(self):
         """Get the file path where preferences file will be stored.
 
-        @returns {String} The configuration path.
+        @return {String} The configuration path.
         """
         return os.path.join(os.path.dirname(
             os.path.dirname(__file__)), "prefs")
@@ -64,8 +64,8 @@ class Preferences:
     def __load(self):
         """Read and store the preferences file.
 
-        @returns {Boolean} True if the preferences file was read,
-                            False otherwise.
+        @return {Boolean} True if the preferences file was read,
+                          False otherwise.
         """
         if os.path.exists(self.__prefsFile):
             try:
@@ -143,6 +143,12 @@ class Preferences:
         return False
 
     def get(self, opt, default):
+        """Retrieve the desired import option from the preferences.
+
+        @param {String} opt TODO.
+        @param {TODO} default TODO.
+        @return {TODO} TODO.
+        """
         # Make sure we have preferences to use
         if self.__prefsData is None or not self.__prefsData["importOpts"]:
             return default
@@ -153,14 +159,15 @@ class Preferences:
             return options[opt]
         return default
 
-    def save(self):
-        """Write the JSON-based preferences file.
+    def save(self, importOpts):
+        """Write the JSON preferences.
 
-        @returns {Boolean} True if the preferences file was written,
-                           False otherwise.
+        @param {Dictionary} importOpts TODO.
+        @return {Boolean} True if the preferences were written,
+                          False otherwise.
         """
         prefs = {
-            "importOpts": {},
+            "importOpts": importOpts,
             "ldPath": self.__ldPath,
             "platform": self.__curPlatform
         }

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -145,7 +145,7 @@ class Preferences:
     def get(self, opt, default):
         """Retrieve the desired import option from the preferences.
 
-        @param {String} opt TODO.
+        @param {String} opt The key for the import option desired.
         @param {TODO} default TODO.
         @return {TODO} TODO.
         """
@@ -183,6 +183,8 @@ class Preferences:
 
         try:
             with open(self.__prefsFile, "wt", encoding="utf_8") as f:
+                # TODO Consder removing the indent parameter
+                # once work on the system is completed.
                 f.write(json.dumps(prefs, indent=4, sort_keys=True))
             Console.log("Preferences saved to {0}".format(self.__prefsFile))
             return True

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -84,10 +84,7 @@ class Preferences:
         @param {String} ldPath The path to confirm an LDraw installation.
         @return {Boolean} True if an installation exists, False otherwise.
         """
-        if os.path.isfile(os.path.join(ldPath, "LDConfig.ldr")):
-            Console.log("Found LDraw installation at {0}".format(ldPath))
-            return True
-        return False
+        return os.path.isfile(os.path.join(ldPath, "LDConfig.ldr"))
 
     def findLDraw(self):
         """Try to find an LDraw installation.
@@ -139,6 +136,7 @@ class Preferences:
         @return {Boolean} True if the installation was set, False otherwise.
         """
         if self.__confirmLDraw(ldPath):
+            Console.log("Found LDraw installation at {0}".format(ldPath))
             self.__ldPath = ldPath.replace("\\", "/")
             return True
         return False

--- a/src/ldprefs.py
+++ b/src/ldprefs.py
@@ -166,6 +166,11 @@ class Preferences:
         @return {Boolean} True if the preferences were written,
                           False otherwise.
         """
+        # Round off any numbers to two decimal places
+        for k, v in importOpts.items():
+            if type(v) == float:
+                importOpts[k] = round(v, 2)
+
         prefs = {
             "importOpts": importOpts,
             "ldPath": self.__ldPath,

--- a/src/ldutils.py
+++ b/src/ldutils.py
@@ -66,12 +66,12 @@ class Console:
 class Preferences:
 
     def __init__(self):
-        self.ldPath = None
+        self.__ldPath = None
         self.__curPlatform = None
         self.__prefsData = None
         self.__prefsPath = self.__getPrefsDir()
         self.__prefsFile = os.path.join(self.__prefsPath, "LDR-Importer.json")
-        self.__getPrefs()
+        self.__load()
 
         self.__paths = {
             "win": [
@@ -99,7 +99,7 @@ class Preferences:
         return os.path.join(os.path.dirname(
             os.path.dirname(__file__)), "prefs")
 
-    def __getPrefs(self):
+    def __load(self):
         """Read and store the preferences file.
 
         @returns {Boolean} True if the preferences file was read,
@@ -136,12 +136,13 @@ class Preferences:
         # The path was previously stored in the preferences
         if self.__prefsData is not None:
             Console.log("Retrieve LDraw path from preferences")
-            self.ldPath = self.__prefsData["ldPath"]
+            self.__ldPath = self.__prefsData["ldPath"]
 
-            Console.log("The current platform is", self.__prefsData["platform"])
+            Console.log("The current platform is {0}".format(
+                        self.__prefsData["platform"]))
             Console.log("The LDraw Parts Library to be used is\n{0}".format(
-                        self.ldPath))
-            return self.__prefsData["ldPath"]
+                        self.__ldPath))
+            return self.__ldPath
 
         # Get and resolve the current platform
         curOS = platform.system()
@@ -153,21 +154,20 @@ class Preferences:
             self.__curPlatform = "linux"
         else:
             self.__curPlatform = "win"
-        Console.log("The current platform is", self.__curPlatform)
+        Console.log("The current platform is {0}".format(self.__curPlatform))
 
         # Perform platform-specific searches to find the LDraw installation
         Console.log("Search {0}-specific paths for the LDraw path".format(
                     self.__curPlatform))
-
         for path in self.__paths[self.__curPlatform]:
             if self.setLDraw(path):
                 return path
 
         # We came up dry, default to Windows default
+        self.__ldPath = self.__paths["win"][0]
         Console.log("Cound not find LDraw installation, default to {0}".format(
-                    self.__paths["win"][0]))
-        self.ldPath = self.__paths["win"][0]
-        return self.__paths["win"][0]
+                    self.__ldPath))
+        return self.__ldPath
 
     def setLDraw(self, ldPath):
         """Set the LDraw installation.
@@ -176,11 +176,11 @@ class Preferences:
         @return {Boolean} True if the installation was set, False otherwise.
         """
         if self.__confirmLDraw(ldPath):
-            self.ldPath = ldPath.replace("\\", "/")
+            self.__ldPath = ldPath.replace("\\", "/")
             return True
         return False
 
-    def savePrefs(self):
+    def save(self):
         """Write the JSON-based preferences file.
 
         @returns {Boolean} True if the preferences file was written,
@@ -188,7 +188,7 @@ class Preferences:
         """
         prefs = {
             "platform": self.__curPlatform,
-            "ldPath": self.ldPath,
+            "ldPath": self.__ldPath,
             "importOpts": {}
         }
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,3 @@
 [flake8]
 ignore =
+max-complexity = 10


### PR DESCRIPTION
Now that we have #101, we can finally persist import options between Blender launches (something that has long been wanted). To note, the LDraw installation was already stored in the old system (though in a dangerous manner) and is already stored using the new system, but this stores _all_ the options now. :smiley: 

I've also used this as an opportunity to further better structure the code and perform a tad bit of code cleanup.
* The Console class is now in it's own module
* The Preferences module has a better file name