### PR TITLE
Correct faulty `isPart` logic and resulting value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,6 @@ blender_python_*/*
 
 Archives/
 Testing/
+prefs/
 
 .idea

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -198,7 +198,7 @@ class LDrawFile(object):
             with open(filename, "rt", encoding="utf_8") as f:
                 lines = f.readlines()
 
-            # Check the part header for subpart status
+            # Check the part header for top-level part status
             isPart = isTopLevelPart(lines[3])
 
             self.part_count += 1
@@ -696,13 +696,10 @@ def isTopLevelPart(headerLine):
     @return {Boolean} True if a top level part, False otherwise
                       or the header does not specify.
     """
-    headerLine = headerLine.lower()
-    if not headerLine.startswith("0 !ldraw_org"):
+    headerLine = headerLine.lower().split()
+    if not headerLine[0] != "0 !ldraw_org":
         return False
-
-    partType = headerLine.lstrip("0 !ldraw_org ")
-    return (partType.startswith("part") or
-            partType.startswith("unofficial_part"))
+    return  headerLine[2] in ("part", "unofficial_part")
 
 
 def locatePart(partName):

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -185,30 +185,21 @@ class LDrawFile(object):
         subfiles = []
 
         while True:
-            isPart = False
-            if os.path.exists(filename):
+            # Get the path to the part
+            filename = (filename if os.path.exists(filename)
+                        else locatePart(filename))
 
-                # Check if this is a main part or a subpart
-                if not isSubPart(filename):
-                    isPart = True
+            # The part does not exist
+            # TODO Do not halt on this condition (#11)
+            if filename is None:
+                return False
 
-                # Read the brick using relative path (to entire model)
-                with open(filename, "rt", encoding="utf_8") as f_in:
-                    lines = f_in.readlines()
+            # Read the located part
+            with open(filename, "rt", encoding="utf_8") as f:
+                lines = f.readlines()
 
-            else:
-                # Search for the brick in the various folders
-                fname, isPart = locate(filename)
-
-                # The brick does not exist
-                # TODO Do not halt on this condition
-                if fname is None:
-                    return False
-
-                # It exists, read it and get the data
-                if os.path.exists(fname):
-                    with open(fname, "rt", encoding="utf_8") as f_in:
-                        lines = f_in.readlines()
+            # Check the part header for subpart status
+            isPart = isTopLevelPart(lines[3])
 
             self.part_count += 1
             if self.part_count > 1 and self.level == 0:
@@ -698,31 +689,35 @@ def getCyclesMilkyWhite(name, diff_color):
     return mat
 
 
-def isSubPart(part):
-    """Check if part is a main part or a subpart."""
-    # FIXME: Remove this function
-    # TODO: A file is a "part" only if its header states so.
-    # (#40#issuecomment-31279788)
-    return str.lower(os.path.split(part)[0]) == "s"
+def isTopLevelPart(headerLine):
+    """Check if the given part is a top level part.
+
+    @param {String} headerLine The header line stating the part level.
+    @return {Boolean} True if a top level part, False otherwise
+                      or the header does not specify.
+    """
+    headerLine = headerLine.lower()
+    if not headerLine.startswith("0 !ldraw_org"):
+        return False
+
+    partType = headerLine.lstrip("0 !ldraw_org ")
+    return (partType.startswith("part") or
+            partType.startswith("unofficial_part"))
 
 
-def locate(pattern):
-    """Check if a part exists."""
-    partName = pattern.replace("\\", os.path.sep)
+def locatePart(partName):
+    """Find the given part in the defined search paths.
 
+    @param {String} partName The part to find.
+    @return {!String} The absolute path to the part if found.
+    """
     for path in paths:
-        # Perform a case-sensitive check
         fname = os.path.join(path, partName)
         if os.path.exists(fname):
-            return (fname, False)
-        else:
-            # Perform a normalized check
-            fname = os.path.join(path, partName.lower())
-            if os.path.exists(fname):
-                return (fname, False)
+            return fname
 
-    Console.log("Could not find file {0}".format(fname))
-    return (None, False)
+    Console.log("Could not find part {0}".format(fname))
+    return None
 
 
 def create_model(self, context, scale):

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -697,9 +697,9 @@ def isTopLevelPart(headerLine):
                       or the header does not specify.
     """
     headerLine = headerLine.lower().split()
-    if not headerLine[0] != "0 !ldraw_org":
+    if headerLine[0] != "0 !ldraw_org":
         return False
-    return  headerLine[2] in ("part", "unofficial_part")
+    return headerLine[2] in ("part", "unofficial_part")
 
 
 def locatePart(partName):
@@ -708,10 +708,22 @@ def locatePart(partName):
     @param {String} partName The part to find.
     @return {!String} The absolute path to the part if found.
     """
+    # Use the OS's path separator to ensure the parts are found
+    partName = partName.replace("\\", os.path.sep)
+
     for path in paths:
+        # Find the part filename using the exact case in the file
         fname = os.path.join(path, partName)
         if os.path.exists(fname):
             return fname
+        
+        # Because case-sensitive file systems, if the first check fails
+        # check again using a normalized part filename
+        # See #112#issuecomment-136719763
+        else:
+            fname = os.path.join(path, partName.lower())
+            if os.path.exists(fname):
+                return fname
 
     Console.log("Could not find part {0}".format(fname))
     return None

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -201,6 +201,12 @@ class LDrawFile(object):
             # Check the part header for top-level part status
             isPart = isTopLevelPart(lines[3])
 
+            # Linked parts relies on the flawed isPart logic (#112)
+            # TODO Correct linked parts to use proper logic
+            # and remove this kludge
+            if LinkParts:  # noqa
+                isPart = filename == fileName  # noqa
+
             self.part_count += 1
             if self.part_count > 1 and self.level == 0:
                 self.subparts.append([filename, self.level + 1, self.mat,
@@ -218,9 +224,10 @@ class LDrawFile(object):
                                 x, y, z, a, b, c,
                                 d, e, f, g, h, i
                             ) = map(float, tmpdate[2:14])
+
                             # Reset orientation of top-level part,
                             # track original orientation
-                            # TODO Check if isPart dependency can be avoided
+                            # TODO Use corrected isPart logic
                             if self.part_count == 1 and isPart and LinkParts:  # noqa
                                 mat_new = self.mat * mathutils.Matrix((
                                     (1, 0, 0, 0),
@@ -247,8 +254,9 @@ class LDrawFile(object):
                             if color == '16':
                                 color = self.colour
                             subfiles.append([new_file, mat_new, color])
+
                             # When top-level part, save orientation separately
-                            # TODO Check if isPart dependency can be avoided
+                            # TODO Use corrected isPart logic
                             if self.part_count == 1 and isPart:
                                 subfiles.append(['orientation',
                                                  orientation, ''])


### PR DESCRIPTION
This PR corrects the faulty `isPart` logic as pointed out by https://github.com/le717/LDR-Importer/issues/40#issuecomment-31279788 which has probably existed since David Pluntze wrote the script. It also ~~cleans up `locatePart()` (formerly `locate()`) and~~ simplifies the code around reading a file.

The problem (which I expected) is linked parts is now broken due to the corrected logic. Previously, `isPart` was true only when reading the base .ldr model. When parts, subparts, and primitives (basically, everything except the .ldr model) were located via `locate()`, `isPart` was automatically `False` even if it was a top-level part (or `True`). Now that the logic is corrected, linked parts is broken.

~~Another thing I noticed was `locatePart()` checked for a file twice: once using exact case checking and another when only the part filename was converted to lowercase. I do not know why this was done (I think to resolve some issue with Linux compatibility), but I am unsure why that would even be a problem.~~

This PR is marked as do not merge for 2 reasons:
* @Tribex From the best I can find in `git blame` you added the double patch checking. Do you remember why (if not, that’s fine) and can you check if this path (which removes the double check) still works on Linux?
* @geertdaelemans I am unable to find what needs to be changed in linked bricks to make it correctly work with the corrected `isPart` logic. Could you pull this branch onto your fork (there are lots of beginner-level guides on how to do that), take a look on fixing it and submit a PR back into this branch? I shouldn’t be editing this anymore (except in case if `locatePart()` needs to be fixed), so it should merge in cleanly.