### PR TITLE
Introduce new colors module

### DIFF
--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -304,12 +304,12 @@ def convertDirectColor(color):
 
 def getMaterial(colour):
     """Get Blender Internal Material Values."""
-    if colour in colors:
+    if colour in colors.getAll():
         if not (colour in mat_list):
             mat = bpy.data.materials.new("Mat_{0}_".format(colour))
-            col = colors[colour]
+            col = colors.get(colour)
 
-            mat.diffuse_color = col["color"]
+            mat.diffuse_color = col["value"]
 
             alpha = col["alpha"]
             if alpha < 1.0:
@@ -366,7 +366,9 @@ def getMaterial(colour):
             mat.diffuse_color = directColor[1]
 
             # Add it to the material lists to avoid duplicate processing
-            colors[colour] = mat
+            # TODO Do not add it to the LDraw-defined colors but only
+            # to the Blender material list
+            colors.add(colour, mat)
             mat_list[colour] = mat
             return mat_list[colour]
 
@@ -375,40 +377,40 @@ def getMaterial(colour):
 
 def getCyclesMaterial(colour):
     """Get Cycles Material Values."""
-    if colour in colors:
+    if colour in colors.getAll():
         if not (colour in mat_list):
-            col = colors[colour]
+            col = colors.get(colour)
 
             if col["name"] == "Milky_White":
                 mat = getCyclesMilkyWhite("Mat_{0}_".format(colour),
-                                          col["color"])
+                                          col["value"])
 
             elif col["material"] == "BASIC" and col["luminance"] == 0:
                 mat = getCyclesBase("Mat_{0}_".format(colour),
-                                    col["color"], col["alpha"])
+                                    col["value"], col["alpha"])
 
             elif col["luminance"] > 0:
-                mat = getCyclesEmit("Mat_{0}_".format(colour), col["color"],
+                mat = getCyclesEmit("Mat_{0}_".format(colour), col["value"],
                                     col["alpha"], col["luminance"])
 
             elif col["material"] == "CHROME":
-                mat = getCyclesChrome("Mat_{0}_".format(colour), col['color'])
+                mat = getCyclesChrome("Mat_{0}_".format(colour), col["value"])
 
             elif col["material"] == "PEARLESCENT":
                 mat = getCyclesPearlMetal("Mat_{0}_".format(colour),
-                                          col["color"])
+                                          col["value"])
 
             elif col["material"] == "METAL":
                 mat = getCyclesPearlMetal("Mat_{0}_".format(colour),
-                                          col["color"])
+                                          col["value"])
 
             elif col["material"] == "RUBBER":
                 mat = getCyclesRubber("Mat_{0}_".format(colour),
-                                      col["color"], col["alpha"])
+                                      col["value"], col["alpha"])
 
             else:
                 mat = getCyclesBase("Mat_{0}_".format(colour),
-                                    col["color"], col["alpha"])
+                                    col["value"], col["alpha"])
 
             mat_list[colour] = mat
 
@@ -424,7 +426,9 @@ def getCyclesMaterial(colour):
                                 directColor[1], 1.0)
 
             # Add it to the material lists to avoid duplicate processing
-            colors[colour] = mat
+            # TODO Do not add it to the LDraw-defined colors but only
+            # to the Blender material list
+            colors.add(colour, mat)
             mat_list[colour] = mat
             return mat_list[colour]
 
@@ -791,7 +795,10 @@ Must be a .ldr or .dat''')
 {0}'''.format(LDrawDir))  # noqa
             return {'CANCELLED'}
 
-        colors = getLDColors(self, LDrawDir)  # noqa
+        # Instance the colors module and
+        # load the LDraw-defined color definitions
+        colors = Colors(LDrawDir, False)  # noqa
+        colors.load()
         mat_list = {}
 
         LDrawFile(context, fileName, 0, trix)
@@ -888,94 +895,6 @@ Must be a .ldr or .dat''')
         self.report({'ERROR'}, '''File not imported ("{0}").
 Check the console logs for more information.'''.format(type(e).__name__))
         return {'CANCELLED'}
-
-
-def getLDColors(self, ldPath):
-    """Parse and extract color material from LDConfig.ldr.
-
-    @param {String} ldPath The path to the LDraw installation.
-    @return {Dictionary} All the colors, with color codes as the keys.
-    """
-    # LDConfig.ldr does not exist for some reason
-    if not os.path.exists(os.path.join(ldPath, "LDConfig.ldr")):
-        self.report({'ERROR'}, '''Could not find LDConfig.ldr at
-{0}
-Check the console logs for more information.'''.format(ldPath))
-
-        Console.log('''ERROR: Could not find LDConfig.ldr at
-{0}'''.format(LDrawDir))  # noqa
-        return {'CANCELLED'}
-
-    Console.log("Parsing LDConfig.ldr")
-    with open(os.path.join(ldPath, "LDConfig.ldr"),
-              "rt", encoding="utf_8") as ldconfig:
-        lines = ldconfig.readlines()
-
-    colors = {}
-
-    for line in lines:
-        if len(line) > 3:
-            if line[2:4].lower() == '!c':
-                line_split = line.split()
-
-                name = line_split[2]
-                code = line_split[4]
-
-                color = {
-                    "name": name,
-                    "color": hexToRgb(line_split[6][1:]),
-                    "alpha": 1.0,
-                    "luminance": 0.0,
-                    "material": "BASIC"
-                }
-
-                if hasColorValue(line_split, "ALPHA"):
-                    color["alpha"] = int(
-                        getColorValue(line_split, "ALPHA")) / 256.0
-
-                if hasColorValue(line_split, "LUMINANCE"):
-                    color["luminance"] = int(
-                        getColorValue(line_split, "LUMINANCE"))
-
-                if hasColorValue(line_split, "CHROME"):
-                    color["material"] = "CHROME"
-
-                if hasColorValue(line_split, "PEARLESCENT"):
-                    color["material"] = "PEARLESCENT"
-
-                if hasColorValue(line_split, 'RUBBER'):
-                    color["material"] = "RUBBER"
-
-                if hasColorValue(line_split, "METAL"):
-                    color["material"] = "METAL"
-
-                if hasColorValue(line_split, "MATERIAL"):
-                    subline = line_split[line_split.index("MATERIAL"):]
-
-                    color["material"] = getColorValue(subline, "MATERIAL")
-                    color["secondary_color"] = getColorValue(
-                        subline, "VALUE")[1:]
-                    color["fraction"] = getColorValue(subline, "FRACTION")
-                    color["vfraction"] = getColorValue(subline, "VFRACTION")
-                    color["size"] = getColorValue(subline, "SIZE")
-                    color["minsize"] = getColorValue(subline, "MINSIZE")
-                    color["maxsize"] = getColorValue(subline, "MAXSIZE")
-
-                colors[code] = color
-
-    return colors
-
-
-def hasColorValue(line, value):
-    """Check if the color value is present."""
-    return value in line
-
-
-def getColorValue(line, value):
-
-    if value in line:
-        n = line.index(value)
-        return line[n + 1]
 
 
 def linkedParts():

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -306,7 +306,7 @@ def getMaterial(colour):
     """Get Blender Internal Material Values."""
     if colour in colors.getAll():
         if not (colour in mat_list):
-            mat = bpy.data.materials.new("Mat_{0}_".format(colour))
+            mat = bpy.data.materials.new("Mat_{0}".format(colour))
             col = colors.get(colour)
 
             mat.diffuse_color = col["value"]
@@ -362,7 +362,7 @@ def getMaterial(colour):
         # We have a direct color on our hands
         if directColor[0]:
             Console.log("Direct color {0} found".format(colour))
-            mat = bpy.data.materials.new("Mat_{0}_".format(colour))
+            mat = bpy.data.materials.new("Mat_{0}".format(colour))
             mat.diffuse_color = directColor[1]
 
             # Add it to the material lists to avoid duplicate processing
@@ -382,34 +382,34 @@ def getCyclesMaterial(colour):
             col = colors.get(colour)
 
             if col["name"] == "Milky_White":
-                mat = getCyclesMilkyWhite("Mat_{0}_".format(colour),
+                mat = getCyclesMilkyWhite("Mat_{0}".format(colour),
                                           col["value"])
 
             elif col["material"] == "BASIC" and col["luminance"] == 0:
-                mat = getCyclesBase("Mat_{0}_".format(colour),
+                mat = getCyclesBase("Mat_{0}".format(colour),
                                     col["value"], col["alpha"])
 
             elif col["luminance"] > 0:
-                mat = getCyclesEmit("Mat_{0}_".format(colour), col["value"],
+                mat = getCyclesEmit("Mat_{0}".format(colour), col["value"],
                                     col["alpha"], col["luminance"])
 
             elif col["material"] == "CHROME":
-                mat = getCyclesChrome("Mat_{0}_".format(colour), col["value"])
+                mat = getCyclesChrome("Mat_{0}".format(colour), col["value"])
 
             elif col["material"] == "PEARLESCENT":
-                mat = getCyclesPearlMetal("Mat_{0}_".format(colour),
+                mat = getCyclesPearlMetal("Mat_{0}".format(colour),
                                           col["value"])
 
             elif col["material"] == "METAL":
-                mat = getCyclesPearlMetal("Mat_{0}_".format(colour),
+                mat = getCyclesPearlMetal("Mat_{0}".format(colour),
                                           col["value"])
 
             elif col["material"] == "RUBBER":
-                mat = getCyclesRubber("Mat_{0}_".format(colour),
+                mat = getCyclesRubber("Mat_{0}".format(colour),
                                       col["value"], col["alpha"])
 
             else:
-                mat = getCyclesBase("Mat_{0}_".format(colour),
+                mat = getCyclesBase("Mat_{0}".format(colour),
                                     col["value"], col["alpha"])
 
             mat_list[colour] = mat
@@ -422,7 +422,7 @@ def getCyclesMaterial(colour):
         # We have a direct color on our hands
         if directColor[0]:
             Console.log("Direct color {0} found".format(colour))
-            mat = getCyclesBase("Mat_{0}_".format(colour),
+            mat = getCyclesBase("Mat_{0}".format(colour),
                                 directColor[1], 1.0)
 
             # Add it to the material lists to avoid duplicate processing

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -95,12 +95,10 @@ class LDrawFile(object):
             for i, f in enumerate(me.polygons):
                 n = self.material_index[i]
 
-                # Use Cycles materials if user is using Cycles
-                if engine == 'CYCLES':
-                    material = getCyclesMaterial(n)
-                # Non-Cycles materials (BI, BGE, POV-Ray, etc...)
-                else:
-                    material = getMaterial(n)
+                # Get the proper materials depending on the current engine
+                # (Cycles vs. BI, BGE, POV-Ray, etc)
+                material = (getCyclesMaterial(n) if engine == "CYCLES"
+                            else getMaterial(n))
 
                 if material is not None:
                     if me.materials.get(material.name) is None:

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -23,7 +23,6 @@ import re
 import math
 import mathutils
 import traceback
-from struct import unpack
 
 import bpy
 from bpy.props import (StringProperty,
@@ -34,6 +33,7 @@ from bpy.props import (StringProperty,
 
 from bpy_extras.io_utils import ImportHelper
 
+from .src.ldcolors import Colors
 from .src.ldconsole import Console
 from .src.ldprefs import Preferences
 
@@ -301,7 +301,7 @@ def convertDirectColor(color):
         re.fullmatch(r"^0x2(?:[A-F0-9]{2}){3}$", color) is None
     ):
         return (False,)
-    return (True, hexToRgb(color.lstrip("0x2")))
+    return (True, colors.hexToRgb(color[3:]))
 
 
 def getMaterial(colour):
@@ -1026,19 +1026,6 @@ def replaceParts(part, color):
     # Change mesh name in combination of .dat-filename and material.
     if mesh is not None:
         mesh.name = "{0} {1}".format(part, color)
-
-
-def hexToRgb(color):
-    """Convert color hex value to the RGB format Blender requires.
-
-    @param {String} color The hex color value to convert.
-                          Can be prefixed with "#".
-    @return {Tuple.<number>} A three-index tuple containing
-                            the converted RGB value.
-    """
-    color = color.lstrip("#")
-    rgbColor = unpack("BBB", bytes.fromhex(color))
-    return tuple([val / 255 for val in rgbColor])
 
 
 # ------------ Operator ------------ #

--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -304,7 +304,7 @@ def convertDirectColor(color):
 
 def getMaterial(colour):
     """Get Blender Internal Material Values."""
-    if colour in colors.getAll():
+    if colors.contains(colour):
         if not (colour in mat_list):
             mat = bpy.data.materials.new("Mat_{0}".format(colour))
             col = colors.get(colour)
@@ -377,7 +377,7 @@ def getMaterial(colour):
 
 def getCyclesMaterial(colour):
     """Get Cycles Material Values."""
-    if colour in colors.getAll():
+    if colors.contains(colour):
         if not (colour in mat_list):
             col = colors.get(colour)
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ scriptFiles = [
     "__version__.py",
     "import_ldraw.py",
     "src/__init__.py",
+    "src/ldcolors.py",
     "src/ldconsole.py",
     "src/ldprefs.py"
 ]

--- a/src/ldcolors.py
+++ b/src/ldcolors.py
@@ -33,7 +33,7 @@ class Colors:
             "filename": self.__colorFile
         }
 
-    def __hexToRgb(self, color):
+    def hexToRgb(self, color):
         """Convert a Hex color value to the RGB format Blender requires.
 
         @param {String} color The hex color value to convert.
@@ -69,9 +69,9 @@ class Colors:
 
     def get(self, code):
         """Get an individual LDraw color object.
-        @param {String} code The color code.
-        @param {!Dictionary} The color code dictionary
-                             if available, None otherwise.
+        @param {String} code The code identifying the color.
+        @param {!Dictionary} The color definition if available,
+                             None otherwise.
         """
         return self.__colors.get(code)
 
@@ -99,7 +99,7 @@ class Colors:
     def load(self):
         """Parse the LDraw color definitions file.
 
-        @return {Dictionary} All defined LDraw colors,
+        @return {Dictionary} The complete LDraw color dictionary
                              with color codes as the keys.
         """
         # Read the color definition file
@@ -121,13 +121,11 @@ class Colors:
                 color = {
                     "alpha": 1.0,
                     "code": code,
-                    "edge": self.__hexToRgb(
-                        self.__getColorValue(line, "edge")),
+                    "edge": self.hexToRgb(self.__getColorValue(line, "edge")),
                     "luminance": 0.0,
                     "material": "basic",
                     "name": self.__getColorValue(line, "!colour"),
-                    "value": self.__hexToRgb(
-                        self.__getColorValue(line, "value"))
+                    "value": self.hexToRgb(self.__getColorValue(line, "value"))
                 }
 
                 # Extract the alpha value

--- a/src/ldcolors.py
+++ b/src/ldcolors.py
@@ -76,11 +76,13 @@ class Colors:
         """
         return self.__colors.get(code)
 
-    def getAll(self):
-        """Get all available LDraw colors.
-        @param {!Dictionary} The complete LDraw color dictionary.
+    def contains(self, code):
+        """Check if a color exists in the color dictionary.
+
+        @param {String} code The code for the corresponding color.
+        @return {Boolean} True if the color was found, False otherwise.
         """
-        return self.__colors
+        return code in self.__colors.keys()
 
     def add(self, code, mat):
         """Add an arbitrary color to the colors dictionary.

--- a/src/ldcolors.py
+++ b/src/ldcolors.py
@@ -81,6 +81,21 @@ class Colors:
         """
         return self.__colors
 
+    def add(self, code, mat):
+        """Add an arbitrary color to the colors dictionary.
+
+        @deprecated This method is implemented to preserve existing
+                    code compatibility and should not be used in new code.
+                    It pollututes the LDraw-defined color definitions.
+                    All non-LDraw materials should be stored separately.
+
+        @param {String} The code identifying the color.
+        @param {*} The structure describing the color.
+        """
+        # Add key to denote it is not an LDraw color definition
+        mat["not_ldraw"] = True
+        self.__colors[code] = mat
+
     def load(self):
         """Parse the LDraw color definitions file.
 

--- a/src/ldcolors.py
+++ b/src/ldcolors.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""LDR Importer GPLv2 license.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+"""
+
+
+import os
+import struct
+
+
+class Colors:
+
+    def __init__(self, ldPath, useAltColors):
+        self.__ldPath = ldPath
+        self.__colorFile = ("LDCfgalt.ldr" if useAltColors else "LDConfig.ldr")
+        self.__colors = {
+            "filename": self.__colorFile
+        }
+
+    def __hexToRgb(self, color):
+        """Convert a Hex color value to the RGB format Blender requires.
+
+        @param {String} color The hex color value to convert.
+                              Can be prefixed with "#".
+        @return {!Tuple.<number>} A three-index tuple containing
+                                  the converted RGB value.
+                                  Otherwise None if the color
+                                  could not be converted.
+        """
+        color = color.lstrip("#")
+        rgbColor = struct.unpack("BBB", bytes.fromhex(color))
+        return tuple([val / 255 for val in rgbColor])
+
+    def __hasColorValue(self, line, value):
+        """Check if the color tag has a specific attribute.
+
+        @param {List} line The color line to search.
+        @param {String} value The attribute to find.
+        @return {Boolean} True if attribute is present, False otherwise.
+        """
+        return value in line
+
+    def __getColorValue(self, line, value):
+        """Get a specific attribute for a given color tag.
+
+        @param {List} line The color line to search.
+        @param {String} value The value to find.
+        @return {!String} The color value is present, None otherwise.
+        """
+        if value in line:
+            return line[line.index(value) + 1]
+        return None
+
+    def get(self, code):
+        """Get an individual LDraw color object.
+        @param {String} code The color code.
+        @param {!Dictionary} The color code dictionary
+                             if available, None otherwise.
+        """
+        return self.__colors.get(code)
+
+    def getAll(self):
+        """Get all available LDraw colors.
+        @param {!Dictionary} The complete LDraw color dictionary.
+        """
+        return self.__colors
+
+    def load(self):
+        """Parse the LDraw color definitions file.
+
+        @return {Dictionary} All defined LDraw colors,
+                             with color codes as the keys.
+        """
+        # Read the color definition file
+        with open(os.path.join(self.__ldPath, self.__colorFile),
+                  "rt", encoding="utf_8") as f:
+            lines = f.readlines()
+
+        for line in lines:
+            # Normalize the lines
+            line = line.lstrip("0").strip().lower()
+
+            # Make sure this is a color
+            if line.startswith("!colour"):
+                line = line.split()
+                code = line[3]
+
+                # Create the color
+                color = {
+                    "alpha": 1.0,
+                    "code": code,
+                    "edge": self.__hexToRgb(
+                        self.__getColorValue(line, "edge")),
+                    "luminance": 0.0,
+                    "material": "basic",
+                    "name": self.__getColorValue(line, "!colour"),
+                    "value": self.__hexToRgb(
+                        self.__getColorValue(line, "value"))
+                }
+
+                # Extract the alpha value
+                if self.__hasColorValue(line, "alpha"):
+                    color["alpha"] = int(
+                        self.__getColorValue(line, "alpha")) / 256
+
+                # Extract the luminance value
+                if self.__hasColorValue(line, "luminance"):
+                    color["luminance"] = int(
+                        self.__getColorValue(line, "luminance"))
+
+                # Extract the valueless attributes
+                if self.__hasColorValue(line, "chrome"):
+                    color["material"] = "chrome"
+                if self.__hasColorValue(line, "pearlescent"):
+                    color["material"] = "pearlescent"
+                if self.__hasColorValue(line, "rubber"):
+                    color["material"] = "rubber"
+                if self.__hasColorValue(line, "metal"):
+                    color["material"] = "metal"
+
+                # Extract extra material values if present
+                if self.__hasColorValue(line, "material"):
+                    subLine = line[line.index("material"):]
+                    color["material"] = self.__getColorValue(subLine,
+                                                             "material")
+                    color["secondary_color"] = self.__getColorValue(
+                        subLine, "value")[1:]
+                    color["fraction"] = self.__getColorValue(subLine,
+                                                             "fraction")
+                    color["vfraction"] = self.__getColorValue(subLine,
+                                                              "vfraction")
+                    color["size"] = self.__getColorValue(subLine, "size")
+                    color["minsize"] = self.__getColorValue(subLine, "minsize")
+                    color["maxsize"] = self.__getColorValue(subLine, "maxsize")
+
+                # Store the color
+                self.__colors[code] = color
+        return self.__colors

--- a/src/ldcolors.py
+++ b/src/ldcolors.py
@@ -69,9 +69,10 @@ class Colors:
 
     def get(self, code):
         """Get an individual LDraw color object.
+
         @param {String} code The code identifying the color.
-        @param {!Dictionary} The color definition if available,
-                             None otherwise.
+        @return {!Dictionary} The color definition if available,
+                              None otherwise.
         """
         return self.__colors.get(code)
 
@@ -89,8 +90,8 @@ class Colors:
                     It pollututes the LDraw-defined color definitions.
                     All non-LDraw materials should be stored separately.
 
-        @param {String} The code identifying the color.
-        @param {*} The structure describing the color.
+        @param {String} code The code identifying the color.
+        @param {*} mat The structure describing the color.
         """
         # Add key to denote it is not an LDraw color definition
         mat["not_ldraw"] = True

--- a/src/ldcolors.py
+++ b/src/ldcolors.py
@@ -21,6 +21,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 import os
 import struct
 
+from .ldconsole import Console
+
 
 class Colors:
 
@@ -86,6 +88,7 @@ class Colors:
                              with color codes as the keys.
         """
         # Read the color definition file
+        Console.log("Parsing {0} color definitions".format(self.__colorFile))
         with open(os.path.join(self.__ldPath, self.__colorFile),
                   "rt", encoding="utf_8") as f:
             lines = f.readlines()


### PR DESCRIPTION
I have had this around for a while and just got around to finishing it.

Per the continued script modernization and modulization, this PR introduces a new `ldcolors` module. It controls all LDraw-defined color work, including parsing the definition file and retrieving the resulting list. It also permits us to use the alternate [LDCfgalt.ldr file](http://www.ldraw.org/article/547) if desired. A preference for such will be added after this is merged.