### PR TITLE
Add logo function

### DIFF
--- a/import_ldraw.py
+++ b/import_ldraw.py
@@ -260,6 +260,14 @@ class LDrawFile(object):
                                 subfiles.append(['orientation',
                                                  orientation, ''])
 
+                            # Adds the LEGO logo on top of every stud. It is
+                            # assumed that the logo3.dat file is available in
+                            # the given p directory
+                            if LogosOpt and new_file == "stud.dat":
+                                mat_logo = self.mat * mathutils.Matrix(
+                                    ((a,b,c,x),(d,e,f,y-4),(g,h,i,z),(0,0,0,1)))
+                                subfiles.append(["logo3.dat", mat_logo, color])
+
                         # Triangle (tri)
                         if tmpdate[0] == "3":
                             self.parse_line(tmpdate)
@@ -825,7 +833,7 @@ Must be a .ldr or .dat''')
                     bpy.ops.mesh.select_all(action='SELECT')
 
                     # Remove doubles, calculate normals
-                    bpy.ops.mesh.remove_doubles(threshold=0.01)
+                    bpy.ops.mesh.remove_doubles(threshold=scale*0.005)
                     bpy.ops.mesh.normals_make_consistent()
 
                     if bpy.ops.object.mode_set.poll():
@@ -1038,6 +1046,12 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         default=prefs.get("addGaps", False)
     )
 
+    addLogos = BoolProperty(
+        name="LEGO Logo On Studs",
+        description="Add the LEGO logo on top of all studs",
+        default=prefs.get("addLogos", False)
+    )
+
     lsynthParts = BoolProperty(
         name="Use LSynth Parts",
         description="Use LSynth parts during import",
@@ -1065,16 +1079,18 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         box.label("Additional Options", icon='PREFERENCES')
         box.prop(self, "altColors")
         box.prop(self, "addGaps")
+        box.prop(self, "addLogos")
         box.prop(self, "lsynthParts")
         box.prop(self, "linkParts")
 
     def execute(self, context):
         """Set import options and start the import process."""
-        global LDrawDir, CleanUpOpt, AltColorsOpt, GapsOpt, LinkParts
+        global LDrawDir, CleanUpOpt, AltColorsOpt, GapsOpt, LogosOpt, LinkParts
         LDrawDir = str(self.ldrawPath)
         CleanUpOpt = str(self.cleanUpParts)
         AltColorsOpt = bool(self.altColors)
         GapsOpt = bool(self.addGaps)
+        LogosOpt = bool(self.addLogos)
         LinkParts = bool(self.linkParts)
 
         # Clear array before adding data if it contains data already
@@ -1136,6 +1152,7 @@ class LDRImporterOps(bpy.types.Operator, ImportHelper):
         # Create the preferences dictionary
         importOpts = {
             "addGaps": self.addGaps,
+            "addLogos": self.addLogos,
             "altColors": self.altColors,
             "cleanUpParts": self.cleanUpParts,
             "importScale": self.importScale,


### PR DESCRIPTION
The user now has the possibility to select an option that puts the LEGO logo on top off all studs in the file. A requirement for this is that the "logo3.dat" file from the LDraw parts tracker is located in the standard p folder.

We still have to figure out the best way to deal with this logo3.dat file. I imagine it's better to just store it somewhere with the script, instead of messing with the users LDraw libraries.
Also, some kind of warning would be nice, because this option tends to slow down the import process a lot because for each part, the logo file has to be read. For this reason especially, it would be great to only import each file once in the beginning and then reference the data.
Finally, I didn't really do anything to ensure the logo's face the right direction. I thought I read somewhere they should be defined right, but in unofficial parts that could not be the case. The question is if errors would be very noticeable.

PS: I'm currently modelling a new logo.dat file that represents the logo's with a mold mark in them for added realism. Would be fun to include this as well, although then it will become hard to judge which stud to assing the mold mark to...